### PR TITLE
🐛 fix: fixed bug when use load_handlers function

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,12 +14,13 @@ def load_handlers(dispatcher: Dispatcher):
     """Load handlers from files in a 'bot' directory."""
     base_path = os.path.join(os.path.dirname(__file__), "bot")
     files = os.listdir(base_path)
-
+    ignored_files = ["__init__.py", "__pycache__"]
     for file_name in files:
-        handler_module, _ = os.path.splitext(file_name)
+        if file_name not in ignored_files:
+            handler_module, _ = os.path.splitext(file_name)
+            module = import_module(f".{handler_module}", "bot")
+            module.init(dispatcher)
 
-        module = import_module(f".{handler_module}", "bot")
-        module.init(dispatcher)
 
 
 def graceful_exit(*_, **__):


### PR DESCRIPTION
Mistakenly detect `__init__.py` and `__Pycache__` files and not found **init method** and cause :
**AttributeError: module '`bot.__init__`' has no attribute '`init`' error** 
when run main.py

![Screenshot 2023-03-13 144452](https://user-images.githubusercontent.com/62311769/224686302-6c047573-0206-4a2b-a0df-bec4a4ca633e.png)

I corrected the code and the error was fixed